### PR TITLE
Convert mail.py to python3

### DIFF
--- a/mail.py
+++ b/mail.py
@@ -1,10 +1,12 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
-import csv, sys, os
-import time
+import csv
+import os
 import smtplib
-from email.MIMEMultipart import MIMEMultipart
-from email.MIMEText import MIMEText
+import sys
+import time
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 
 """
 expects a csv file with assignments of the form:
@@ -21,7 +23,7 @@ subj = "OS Exam 1"
 msg = "You are assigned seat %s."
 
 if len(sys.argv) < 2:
-    print "USAGE: %s <assignment_csv_filename>" % sys.argv[0]
+    print("USAGE: %s <assignment_csv_filename>" % sys.argv[0])
     sys.exit(1)
 
 filename = sys.argv[1]
@@ -43,7 +45,7 @@ DEFAULT_BACKOFF = 30 # seconds
 next_backoff = DEFAULT_BACKOFF
 
 for uni, toname, seat in students:
-    print uni, msg % seat
+    print(uni, msg % seat)
 
     toaddr = "%s@columbia.edu" % uni
 
@@ -67,8 +69,8 @@ for uni, toname, seat in students:
             next_backoff = DEFAULT_BACKOFF
             break
         except (smtplib.SMTPException, smtplib.SMTPServerDisconnected) as e:
-            print e
-            print "Waiting %s seconds" % next_backoff
+            print(e)
+            print("Waiting %s seconds" % next_backoff)
             time.sleep(next_backoff)
             next_backoff *= 2
             server = None

--- a/mail.py
+++ b/mail.py
@@ -69,7 +69,7 @@ for uni, toname, seat in students:
             next_backoff = DEFAULT_BACKOFF
             break
         except (smtplib.SMTPException, smtplib.SMTPServerDisconnected) as e:
-            print(e)
+            print(f"{e.smtp_code}: {e.smtp_error.decode()}")
             print("Waiting %s seconds" % next_backoff)
             time.sleep(next_backoff)
             next_backoff *= 2


### PR DESCRIPTION
Resolves #9

Kind of janky but it works. Also cleans up error handling by splitting error into code and message.

I don't think we really use this anymore, but if we do, there are some obvious improvements that can be made:
- Use `argparse` and avoid hardcoding name, email, subject, and reply-to fields
- Switch to more modern string formatting
- Use context manager for file

Also, I think this may not work for Barnard emails since columbia.edu emails don't automatically redirect anymore